### PR TITLE
Fix: Build Optimization Errors in Angular

### DIFF
--- a/src/baseEntities/AllocationStamp.ts
+++ b/src/baseEntities/AllocationStamp.ts
@@ -8,7 +8,7 @@ import { Position } from './Position'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum AllocationStampTypeEnum {
+export const enum AllocationStampTypeEnum {
     Planned = '1',
     EffectiveRealized = '4',
 }

--- a/src/baseEntities/AttachedFile.ts
+++ b/src/baseEntities/AttachedFile.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum AttachedFilePreserveEnum {
+export const enum AttachedFilePreserveEnum {
     TaskControllerDoesNotNeedToPreserveAttachedFile = '1',
     PreserveOnTaskControllerAndSendBackToFMIS = '2',
 }

--- a/src/baseEntities/CodedComment.ts
+++ b/src/baseEntities/CodedComment.ts
@@ -8,7 +8,7 @@ import { CodedCommentListValue } from './CodedCommentListValue'
 
 import { Entity, EntityConstructor, AttributesDescription, ISOXMLReference } from '../types'
 
-export enum CodedCommentCodedCommentScopeEnum {
+export const enum CodedCommentCodedCommentScopeEnum {
     Point = '1',
     Global = '2',
     Continuous = '3',

--- a/src/baseEntities/DeviceElement.ts
+++ b/src/baseEntities/DeviceElement.ts
@@ -8,7 +8,7 @@ import { DeviceObjectReference } from './DeviceObjectReference'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum DeviceElementDeviceElementTypeEnum {
+export const enum DeviceElementDeviceElementTypeEnum {
     Device = '1',
     Function = '2',
     Bin = '3',

--- a/src/baseEntities/ExternalFileReference.ts
+++ b/src/baseEntities/ExternalFileReference.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum ExternalFileReferenceFiletypeEnum {
+export const enum ExternalFileReferenceFiletypeEnum {
     XML = '1',
 }
 

--- a/src/baseEntities/Grid.ts
+++ b/src/baseEntities/Grid.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum GridGridTypeEnum {
+export const enum GridGridTypeEnum {
     GridType1 = '1',
     GridType2 = '2',
 }

--- a/src/baseEntities/GuidancePattern.ts
+++ b/src/baseEntities/GuidancePattern.ts
@@ -9,31 +9,31 @@ import { Polygon } from './Polygon'
 
 import { Entity, EntityConstructor, AttributesDescription, ISOXMLReference } from '../types'
 
-export enum GuidancePatternGuidancePatternTypeEnum {
+export const enum GuidancePatternGuidancePatternTypeEnum {
     AB = '1',
     A = '2',
     Curve = '3',
     Pivot = '4',
     Spiral = '5',
 }
-export enum GuidancePatternGuidancePatternOptionsEnum {
+export const enum GuidancePatternGuidancePatternOptionsEnum {
     ClockwiseForPivot = '1',
     CounterClockwiseForPivot = '2',
     FullCircleForPivot = '3',
 }
-export enum GuidancePatternGuidancePatternPropagationDirectionEnum {
+export const enum GuidancePatternGuidancePatternPropagationDirectionEnum {
     BothDirections = '1',
     LeftDirectionOnly = '2',
     RightDirectionOnly = '3',
     NoPropagation = '4',
 }
-export enum GuidancePatternGuidancePatternExtensionEnum {
+export const enum GuidancePatternGuidancePatternExtensionEnum {
     FromBothFirstAndLastPoint = '1',
     FromFirstPointAOnly = '2',
     FromLastPointBOnly = '3',
     NoExtensions = '4',
 }
-export enum GuidancePatternGuidancePatternGNSSMethodEnum {
+export const enum GuidancePatternGuidancePatternGNSSMethodEnum {
     NoGPSFix = '0',
     GNSSFix = '1',
     DGNSSFix = '2',

--- a/src/baseEntities/ISO11783LinkListFile.ts
+++ b/src/baseEntities/ISO11783LinkListFile.ts
@@ -8,16 +8,16 @@ import { LinkGroup } from './LinkGroup'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum ISO11783LinkListFileVersionMajorEnum {
+export const enum ISO11783LinkListFileVersionMajorEnum {
     TheVersionOfTheSecondEditionPublishedAsAFinalDraftInternationalStandard = '4',
 }
-export enum ISO11783LinkListFileVersionMinorEnum {
+export const enum ISO11783LinkListFileVersionMinorEnum {
     Value0 = '0',
     Value1 = '1',
     Value2 = '2',
     Value3 = '3',
 }
-export enum ISO11783LinkListFileDataTransferOriginEnum {
+export const enum ISO11783LinkListFileDataTransferOriginEnum {
     FMIS = '1',
     MICS = '2',
 }

--- a/src/baseEntities/ISO11783TaskDataFile.ts
+++ b/src/baseEntities/ISO11783TaskDataFile.ts
@@ -26,16 +26,16 @@ import { ExternalFileReference } from './ExternalFileReference'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum ISO11783TaskDataFileVersionMajorEnum {
+export const enum ISO11783TaskDataFileVersionMajorEnum {
     TheVersionOfTheSecondEditionPublishedAsAFinalDraftInternationalStandard = '4',
 }
-export enum ISO11783TaskDataFileVersionMinorEnum {
+export const enum ISO11783TaskDataFileVersionMinorEnum {
     Value0 = '0',
     Value1 = '1',
     Value2 = '2',
     Value3 = '3',
 }
-export enum ISO11783TaskDataFileDataTransferOriginEnum {
+export const enum ISO11783TaskDataFileDataTransferOriginEnum {
     FMIS = '1',
     MICS = '2',
 }

--- a/src/baseEntities/LineString.ts
+++ b/src/baseEntities/LineString.ts
@@ -8,7 +8,7 @@ import { Point } from './Point'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum LineStringLineStringTypeEnum {
+export const enum LineStringLineStringTypeEnum {
     PolygonExterior = '1',
     PolygonInterior = '2',
     TramLine = '3',

--- a/src/baseEntities/LinkGroup.ts
+++ b/src/baseEntities/LinkGroup.ts
@@ -8,7 +8,7 @@ import { Link } from './Link'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum LinkGroupLinkGroupTypeEnum {
+export const enum LinkGroupLinkGroupTypeEnum {
     UUIDs = '1',
     ManufacturerProprietary = '2',
     UniqueResolvableURIs = '3',

--- a/src/baseEntities/Point.ts
+++ b/src/baseEntities/Point.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum PointPointTypeEnum {
+export const enum PointPointTypeEnum {
     Flag = '1',
     Other = '2',
     FieldAccess = '3',

--- a/src/baseEntities/Polygon.ts
+++ b/src/baseEntities/Polygon.ts
@@ -8,7 +8,7 @@ import { LineString } from './LineString'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum PolygonPolygonTypeEnum {
+export const enum PolygonPolygonTypeEnum {
     PartfieldBoundary = '1',
     TreatmentZone = '2',
     WaterSurface = '3',

--- a/src/baseEntities/Position.ts
+++ b/src/baseEntities/Position.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum PositionPositionStatusEnum {
+export const enum PositionPositionStatusEnum {
     NoGPSFix = '0',
     GNSSFix = '1',
     DGNSSFix = '2',

--- a/src/baseEntities/Product.ts
+++ b/src/baseEntities/Product.ts
@@ -8,7 +8,7 @@ import { ProductRelation } from './ProductRelation'
 
 import { Entity, EntityConstructor, AttributesDescription, ISOXMLReference } from '../types'
 
-export enum ProductProductTypeEnum {
+export const enum ProductProductTypeEnum {
     SingleDefault = '1',
     Mixture = '2',
     TemporaryMixture = '3',

--- a/src/baseEntities/ProductAllocation.ts
+++ b/src/baseEntities/ProductAllocation.ts
@@ -8,7 +8,7 @@ import { AllocationStamp } from './AllocationStamp'
 
 import { Entity, EntityConstructor, AttributesDescription, ISOXMLReference } from '../types'
 
-export enum ProductAllocationTransferModeEnum {
+export const enum ProductAllocationTransferModeEnum {
     Filling = '1',
     Emptying = '2',
     Remainder = '3',

--- a/src/baseEntities/ProductGroup.ts
+++ b/src/baseEntities/ProductGroup.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum ProductGroupProductGroupTypeEnum {
+export const enum ProductGroupProductGroupTypeEnum {
     ProductGroupDefault = '1',
     CropType = '2',
 }

--- a/src/baseEntities/Task.ts
+++ b/src/baseEntities/Task.ts
@@ -20,7 +20,7 @@ import { GuidanceAllocation } from './GuidanceAllocation'
 
 import { Entity, EntityConstructor, AttributesDescription, ISOXMLReference } from '../types'
 
-export enum TaskTaskStatusEnum {
+export const enum TaskTaskStatusEnum {
     Planned = '1',
     Running = '2',
     Paused = '3',

--- a/src/baseEntities/TaskControllerCapabilities.ts
+++ b/src/baseEntities/TaskControllerCapabilities.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum TaskControllerCapabilitiesVersionNumberEnum {
+export const enum TaskControllerCapabilitiesVersionNumberEnum {
     TheVersionOfTheDIS1FirstDraftInternationalStandard = '0',
     TheVersionOfTheFDIS1FinalDraftInternationalStandardFirstEdition = '1',
     TheVersionOfTheFDIS2AndTheFirstEditionPublishedAsAnInternationalStandard = '2',

--- a/src/baseEntities/Time.ts
+++ b/src/baseEntities/Time.ts
@@ -9,7 +9,7 @@ import { DataLogValue } from './DataLogValue'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum TimeTypeEnum {
+export const enum TimeTypeEnum {
     Planned = '1',
     Preliminary = '2',
     Effective = '4',

--- a/src/baseEntities/TimeLog.ts
+++ b/src/baseEntities/TimeLog.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum TimeLogTimeLogTypeEnum {
+export const enum TimeLogTimeLogTypeEnum {
     BinaryTimelogFileType1 = '1',
 }
 

--- a/src/baseEntities/TimelogPosition.ts
+++ b/src/baseEntities/TimelogPosition.ts
@@ -7,7 +7,7 @@ import { XMLElement } from '../types'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum TimelogPositionPositionStatusEnum {
+export const enum TimelogPositionPositionStatusEnum {
     NoGPSFix = '0',
     GNSSFix = '1',
     DGNSSFix = '2',

--- a/src/baseEntities/TimelogTime.ts
+++ b/src/baseEntities/TimelogTime.ts
@@ -9,7 +9,7 @@ import { TimelogDataLogValue } from './TimelogDataLogValue'
 
 import { Entity, EntityConstructor, AttributesDescription } from '../types'
 
-export enum TimelogTimeTypeEnum {
+export const enum TimelogTimeTypeEnum {
     Effective = '4',
 }
 

--- a/src/baseEntities/constants.ts
+++ b/src/baseEntities/constants.ts
@@ -1,4 +1,4 @@
-export enum TAGS {
+export const enum TAGS {
     AllocationStamp = 'ASP',
     BaseStation = 'BSN',
     CodedComment = 'CCT',


### PR DESCRIPTION
### Fix Runtime Errors in Angular Post Build Optimization by Converting Enum to Const Enum

This PR resolves runtime errors encountered after build optimization in Angular. The issue manifested after the build process, with `buildOptimizer` enabled, where regular enums were not correctly recognized. Converting `enums` to `const enums` effectively fixes this issue.

This change is crucial because `const enums`, being inlined during the TypeScript compilation, circumvent the problems associated with module resolution and property accessibility in the compiled JavaScript. This ensures that the values are directly accessible as constants, enhancing compatibility and stability when the library is used in the application.

Issue link with some additional info: https://github.com/dev4Agriculture/isoxml-js/issues/14
