### PR TITLE
Added altitude to fromGeoJSONCoordinates() method on ExtendedLineString.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isoxml",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "isoxml",
-      "version": "1.9.7",
+      "version": "1.9.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@turf/turf": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isoxml",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "JavaScript library to parse and generate ISOXML (ISO11783-10) files",
   "keywords": [
     "isoxml",

--- a/src/entities/LineString.spec.ts
+++ b/src/entities/LineString.spec.ts
@@ -1,0 +1,47 @@
+import { ISOXMLManager } from "../ISOXMLManager"
+import { LineStringLineStringTypeEnum } from "../baseEntities"
+import { ExtendedLineString } from "./LineString"
+
+describe("LineString Entity", () => {
+    it("should be constructed from GeoJSON without altitude - version 4", async () => {
+        const isoxmlManager = new ISOXMLManager({version: 4})
+        const lineString = ExtendedLineString.fromGeoJSONCoordinates(
+            [
+                [-44.904, 61.277],
+                [-44.852, 61.034],
+            ],
+            isoxmlManager,
+            LineStringLineStringTypeEnum.GuidancePattern
+        )
+
+        expect(lineString.attributes.Point?.[0].attributes.PointEast).toEqual(-44.904)
+        expect(lineString.attributes.Point?.[0].attributes.PointNorth).toEqual(61.277)
+        expect(lineString.attributes.Point?.[0].attributes.PointUp).toBeUndefined()
+
+        expect(lineString.attributes.Point?.[1].attributes.PointEast).toEqual(-44.852)
+        expect(lineString.attributes.Point?.[1].attributes.PointNorth).toEqual(61.034)
+        expect(lineString.attributes.Point?.[1].attributes.PointUp).toBeUndefined()
+    })
+})
+
+describe("LineString Entity", () => {
+  it("should be constructed from GeoJSON with altitude - version 4", async () => {
+      const isoxmlManager = new ISOXMLManager({version: 4})
+      const lineString = ExtendedLineString.fromGeoJSONCoordinates(
+          [
+              [-44.904, 61.277, 12.140],
+              [-44.852, 61.034, 12.213],
+          ],
+          isoxmlManager,
+          LineStringLineStringTypeEnum.GuidancePattern
+      )
+
+      expect(lineString.attributes.Point?.[0].attributes.PointEast).toEqual(-44.904)
+      expect(lineString.attributes.Point?.[0].attributes.PointNorth).toEqual(61.277)
+      expect(lineString.attributes.Point?.[0].attributes.PointUp).toEqual(0.012140)
+
+      expect(lineString.attributes.Point?.[1].attributes.PointEast).toEqual(-44.852)
+      expect(lineString.attributes.Point?.[1].attributes.PointNorth).toEqual(61.034)
+      expect(lineString.attributes.Point?.[1].attributes.PointUp).toEqual(0.012213)
+  })
+})

--- a/src/entities/LineString.ts
+++ b/src/entities/LineString.ts
@@ -35,7 +35,8 @@ export class ExtendedLineString extends LineString {
             Point: coordinates.map(c => new Point({
                 PointType: PointPointTypeEnum.Other,
                 PointNorth: c[1],
-                PointEast: c[0]
+                PointEast: c[0],
+                PointUp: c[2]
             }, isoxmlManager))
         }, isoxmlManager)
     }

--- a/src/entities/LineString.ts
+++ b/src/entities/LineString.ts
@@ -36,7 +36,7 @@ export class ExtendedLineString extends LineString {
                 PointType: PointPointTypeEnum.Other,
                 PointNorth: c[1],
                 PointEast: c[0],
-                PointUp: c[2]
+                ...c[2] != undefined && {PointUp: c[2] / 1000},
             }, isoxmlManager))
         }, isoxmlManager)
     }


### PR DESCRIPTION
I noticed that altitude is ignored when parsing GeoJSON data and setting position values on the Point XML element. I mapped altitude to PointUp.

Let me know if I missed something. This is my first open-source contribution. Thanks!