### PR TITLE
TaskEntry: add possibility to set PDVs for all default TZNs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isoxml",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "isoxml",
-      "version": "1.9.8",
+      "version": "1.9.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@turf/turf": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isoxml",
-  "version": "1.9.9",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "isoxml",
-      "version": "1.9.9",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@turf/turf": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isoxml",
-  "version": "1.9.9",
+  "version": "1.10.0",
   "description": "JavaScript library to parse and generate ISOXML (ISO11783-10) files",
   "keywords": [
     "isoxml",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isoxml",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "JavaScript library to parse and generate ISOXML (ISO11783-10) files",
   "keywords": [
     "isoxml",

--- a/src/entities/Task.spec.ts
+++ b/src/entities/Task.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { ISOXMLManager } from '../ISOXMLManager'
 import { ExtendedTask } from './Task'
-import { TaskTaskStatusEnum, ValuePresentation } from '../baseEntities'
+import { TaskTaskStatusEnum, TreatmentZone, ValuePresentation } from '../baseEntities'
 
 describe('Task Entity', () => {
     it('should add Grid from GeoJSON', async () => {
@@ -62,7 +62,7 @@ describe('Task Entity', () => {
             UnitDesignator: 'custom-unit'
         }, isoxmlManager)
 
-        task.addGridFromGeoJSON(geoJSONdata, 1, null, isoxmlManager.registerEntity(vpn))
+        task.addGridFromGeoJSON(geoJSONdata, 1, undefined, isoxmlManager.registerEntity(vpn))
         const descriptionAfterWithVPN = task.getGridValuesDescription()
 
         expect(descriptionAfterWithVPN).toHaveLength(1)
@@ -70,5 +70,37 @@ describe('Task Entity', () => {
         expect(descriptionAfterWithVPN[0].scale).toBe(2)
         expect(descriptionAfterWithVPN[0].offset).toBe(20)
         expect(descriptionAfterWithVPN[0].unit).toBe('custom-unit')
+    })
+
+    it('should support positionLostValue and outOfFieldValue', async () => {
+        const geoJSONdata = JSON.parse(readFileSync('./data/test.geojson', 'utf-8'))
+        const isoxmlManager = new ISOXMLManager()
+
+        const task = new ExtendedTask({
+            TaskStatus: TaskTaskStatusEnum.Planned
+        }, isoxmlManager)
+
+        task.addGridFromGeoJSON(geoJSONdata, 1, undefined, undefined, 11, 22, 33)
+
+        expect(task.attributes.TreatmentZone).toHaveLength(4)
+
+        const getTZNValue = (code: number) => {
+            const tzn = task.attributes.TreatmentZone!.find(
+                tzn => tzn.attributes.TreatmentZoneCode == code
+            )
+            return tzn?.attributes.ProcessDataVariable![0].attributes.ProcessDataValue
+        }
+
+        expect(getTZNValue(task.attributes.DefaultTreatmentZoneCode!)).toBe(11)
+        expect(getTZNValue(task.attributes.PositionLostTreatmentZoneCode!)).toBe(22)
+        expect(getTZNValue(task.attributes.OutOfFieldTreatmentZoneCode!)).toBe(33)
+
+        const tznCodes = new Set([
+            task.attributes.DefaultTreatmentZoneCode,
+            task.attributes.PositionLostTreatmentZoneCode,
+            task.attributes.OutOfFieldTreatmentZoneCode,
+            task.attributes.Grid![0].attributes.TreatmentZoneCode
+        ])
+        expect(tznCodes.size).toBe(4) // all TZN codes are different
     })
 })

--- a/src/entities/Task.spec.ts
+++ b/src/entities/Task.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { ISOXMLManager } from '../ISOXMLManager'
 import { ExtendedTask } from './Task'
-import { TaskTaskStatusEnum, TreatmentZone, ValuePresentation } from '../baseEntities'
+import { TaskTaskStatusEnum, ValuePresentation } from '../baseEntities'
 
 describe('Task Entity', () => {
     it('should add Grid from GeoJSON', async () => {


### PR DESCRIPTION
Changes:
  1. Added new optional attributes to `Task.addGridFromGeoJSON()` to set PDVs for all the default TZNs
  2. Improved managing of existing in the task TZNs