### PR TITLE
Bugfix/datetime v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isoxml",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "JavaScript library to parse and generate ISOXML (ISO11783-10) files",
   "keywords": [
     "isoxml",

--- a/src/ISOXMLManager.spec.ts
+++ b/src/ISOXMLManager.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import JSZip from 'jszip'
 import { TaskTaskStatusEnum } from './baseEntities'
 import { TAGS } from './baseEntities/constants'

--- a/src/ISOXMLManager.spec.ts
+++ b/src/ISOXMLManager.spec.ts
@@ -306,10 +306,6 @@ describe('ISOXML Manager', () => {
         expect(isoxmlManager.createEntityFromXML('unknown_tag' as any, {})).toBeNull()
     })
 
-    it('should not have timezones in V3', async () => {
-        const isoxmlManager = new ISOXMLManager
-    })
-
     describe('registerEntity', () => {
         it('should catch inconsistency errors in entities', async () => {
             const isoxmlManager = new ISOXMLManager()

--- a/src/ISOXMLManager.spec.ts
+++ b/src/ISOXMLManager.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import JSZip from 'jszip'
 import { TaskTaskStatusEnum } from './baseEntities'
 import { TAGS } from './baseEntities/constants'
@@ -199,7 +199,6 @@ describe('ISOXML Manager', () => {
         expect(isoxmlManager.getWarnings()).toHaveLength(0)
         isoxmlManager.updateOptions({version: 3})
         const data = await isoxmlManager.saveISOXML()
-        // writeFileSync('./data/test_grid_out.zip', data)
 
         const isoxmlManager2 = new ISOXMLManager()
         await isoxmlManager2.parseISOXMLFile(data, 'application/zip')
@@ -208,10 +207,26 @@ describe('ISOXML Manager', () => {
         expect(isoxmlManager2.rootElement.attributes).not.toHaveProperty('BaseStation')
         expect(isoxmlManager2.rootElement.attributes.CropType[0].attributes).not.toHaveProperty('ProductGroupIdRef')
         expect(isoxmlManager2.rootElement.attributes.Task.length==1)
-        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time.length>0)
-        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time[0].attributes.Start !== "")
-        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time[0].attributes.Start.endsWith("21:00:00"))
     })
+
+    it('Ensure that Timestamps do not have a timezone in V3', async () =>{
+        const isoxmlData = readFileSync('./data/task_full.zip')
+        const isoxmlManager = new ISOXMLManager()
+        await isoxmlManager.parseISOXMLFile(new Uint8Array(isoxmlData.buffer), 'application/zip')
+        expect(isoxmlManager.getWarnings()).toHaveLength(0)
+        isoxmlManager.updateOptions({version: 3})
+        const data = await isoxmlManager.saveISOXML()
+        const zip = await JSZip.loadAsync(data)
+        expect(zip.file("TASKDATA/TASKDATA.XML")).toBeTruthy()
+        const xmlFile = zip.file("TASKDATA/TASKDATA.XML")
+        const text = await xmlFile.async('text')
+        expect(!text.includes("000Z"))
+        expect(text.includes('2021-03-18T21:00:00.000Z'))
+        
+
+    },4000)
+
+
 
     it('should add warnings', async () => {
         const isoxmlData = readFileSync('./data/task_with_warnings.zip')

--- a/src/ISOXMLManager.spec.ts
+++ b/src/ISOXMLManager.spec.ts
@@ -207,6 +207,7 @@ describe('ISOXML Manager', () => {
         expect(isoxmlManager2.options.version).toBe(3)
         expect(isoxmlManager2.rootElement.attributes).not.toHaveProperty('BaseStation')
         expect(isoxmlManager2.rootElement.attributes.CropType[0].attributes).not.toHaveProperty('ProductGroupIdRef')
+        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time[0].attributes.Start.split('.').length==1)
     })
 
     it('should add warnings', async () => {
@@ -303,6 +304,10 @@ describe('ISOXML Manager', () => {
         const isoxmlManager = new ISOXMLManager()
         expect(isoxmlManager.createEntityFromAttributes('unknown_tag' as any, {})).toBeNull()
         expect(isoxmlManager.createEntityFromXML('unknown_tag' as any, {})).toBeNull()
+    })
+
+    it('should not have timezones in V3', async () => {
+        const isoxmlManager = new ISOXMLManager
     })
 
     describe('registerEntity', () => {

--- a/src/ISOXMLManager.spec.ts
+++ b/src/ISOXMLManager.spec.ts
@@ -207,7 +207,10 @@ describe('ISOXML Manager', () => {
         expect(isoxmlManager2.options.version).toBe(3)
         expect(isoxmlManager2.rootElement.attributes).not.toHaveProperty('BaseStation')
         expect(isoxmlManager2.rootElement.attributes.CropType[0].attributes).not.toHaveProperty('ProductGroupIdRef')
-        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time[0].attributes.Start.split('.').length==1)
+        expect(isoxmlManager2.rootElement.attributes.Task.length==1)
+        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time.length>0)
+        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time[0].attributes.Start !== "")
+        expect(isoxmlManager2.rootElement.attributes.Task[0].attributes.Time[0].attributes.Start.endsWith("21:00:00"))
     })
 
     it('should add warnings', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,8 +58,15 @@ function numberGenerator (value: number, attrDescription: AttributeDescription):
     }
 }
 
-function dateTimeGenerator (value: Date): string {
-    return value.toISOString()
+function dateTimeGenerator (value: Date, attrDescription: AttributeDescription, isoxmlManager: ISOXMLManager ): string {
+    if(isoxmlManager){
+        if(isoxmlManager.options.version === 3){
+            return value.toISOString().split(".")[0]
+        } else 
+        {
+            return value.toISOString()
+        }
+    }
 }
 
 const PARSERS: {[xsdType: string]: AttributeParser} = {


### PR DESCRIPTION
The functionality of TimeZones was added in ISOXML only in Version 4. Even though it might be no problem for most of the systems out there, we should ensure not to generate ISOXML that might be recognized as invalid.
