### PR TITLE
PR correct TimelogRecord-times

### DIFF
--- a/src/entities/TimeLog/TimeLog.spec.ts
+++ b/src/entities/TimeLog/TimeLog.spec.ts
@@ -18,6 +18,19 @@ describe('TimeLog Entity', () => {
         expect(parsedTimeLog.bbox).toEqual([9.5777866, 45.5277534, 9.5779409, 45.5278066])
     })
 
+    it('should convert TimeLog-record times into correct Date-objects', async () => {
+        const isoxmlData = readFileSync('./data/2021-04-09T15_33_26_taskdata.zip')
+        const isoxmlManager = new ISOXMLManager({version: 4})
+
+        await isoxmlManager.parseISOXMLFile(new Uint8Array(isoxmlData.buffer), 'application/zip')
+
+        const timeLog = isoxmlManager.getEntityByXmlId<Task>('TSK-1').attributes.TimeLog[0] as ExtendedTimeLog
+
+        const parsedTimeLog = timeLog.parseBinaryFile()
+
+        expect(parsedTimeLog.timeLogs[0].time.toUTCString()).toEqual('Fri, 09 Apr 2021 14:54:04 GMT')
+    })
+
     it('should detect outliers', async () => {
         const isoxmlData = readFileSync('./data/2021-04-09T15_33_26_taskdata.zip')
         const isoxmlManager = new ISOXMLManager()
@@ -31,6 +44,7 @@ describe('TimeLog Entity', () => {
         expect(ranges[2].minValue).toBe(-2231)
         expect(ranges[2].maxValue).toBe(334)
     })
+
 
     it('should fill missing values', async () => {
         const isoxmlData = readFileSync('./data/2021-04-09T15_33_26_taskdata.zip')

--- a/src/entities/TimeLog/index.ts
+++ b/src/entities/TimeLog/index.ts
@@ -129,7 +129,7 @@ export class ExtendedTimeLog extends TimeLog {
                 // therefore, add milliseconds between 1970-01-01 midnight and 1980-01-01 midnight
                 const MILLISECONDS_JS_ISO_DIFFERENCE = Date.UTC(1980, 0, 1)
 
-                record.time = new Date(MILLISECONDS_JS_ISO_DIFFERENCE + 1000 * 60 * 60 * 24 * days + ms)
+                record.time = new Date(MILLISECONDS_JS_ISO_DIFFERENCE + 1000 * 60 * 60 * 24 * days + ms) // TODO: timezones
 
                 if (headerPos) {
                     if (headerPos.PositionNorth === null) {

--- a/src/entities/TimeLog/index.ts
+++ b/src/entities/TimeLog/index.ts
@@ -124,7 +124,12 @@ export class ExtendedTimeLog extends TimeLog {
                 const ms = reader.nextUint32()
                 const days = reader.nextUint16()
 
-                record.time = new Date(1000 * 60 * 60 * 24 * days + ms) //TODO: timezone ?
+                // Date-class constructor requires milliseconds since 1970-01-01
+                // Binary file provides days since 1980-01-01 (see ISO for reference)
+                // therefore add ten years to get the correct time
+                const TEN_YEARS_MILLISECONDS = 10 * 365 * 24 * 60 * 60 * 1000;
+
+                record.time = new Date(TEN_YEARS_MILLISECONDS + 1000 * 60 * 60 * 24 * days + ms) //TODO: timezone ?
 
                 if (headerPos) {
                     if (headerPos.PositionNorth === null) {

--- a/src/entities/TimeLog/index.ts
+++ b/src/entities/TimeLog/index.ts
@@ -126,10 +126,10 @@ export class ExtendedTimeLog extends TimeLog {
 
                 // Date-class constructor requires milliseconds since 1970-01-01
                 // Binary file provides days since 1980-01-01 (see ISO for reference)
-                // therefore add ten years to get the correct time
-                const TEN_YEARS_MILLISECONDS = 10 * 365 * 24 * 60 * 60 * 1000;
+                // therefore, add milliseconds between 1970-01-01 midnight and 1980-01-01 midnight
+                const MILLISECONDS_JS_ISO_DIFFERENCE = Date.UTC(1980, 0, 1)
 
-                record.time = new Date(TEN_YEARS_MILLISECONDS + 1000 * 60 * 60 * 24 * days + ms) //TODO: timezone ?
+                record.time = new Date(MILLISECONDS_JS_ISO_DIFFERENCE + 1000 * 60 * 60 * 24 * days + ms)
 
                 if (headerPos) {
                     if (headerPos.PositionNorth === null) {


### PR DESCRIPTION
The ISO 11783-10 defines the `TimeStart: date`-value in the Timelog binary file as follows:
'Local time zone days since **1980-01-01**'

The typescript Date-class constructor takes a parameter (type: number) which represents the milliseconds since **1970-01-01**.

Therefore, I added ten years in milliseconds to the Timelog-record time when constructing the Date-object.

Based on the files I tested, it works as intended. However, I would appreciate any feedback to ensure the change is correct.