### PR TITLE
Support multi-value Grids of Type 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
     "@typescript-eslint/no-explicit-any": "off",
     "semi": "off",
     "@typescript-eslint/semi": ["error", "never"],
-    "max-len": ["error", { "code": 120 }]
+    "max-len": ["error", { "code": 120 }],
+    "no-trailing-spaces": "error"
   },
   "env": {
     "node": true

--- a/generation/index.ts
+++ b/generation/index.ts
@@ -97,13 +97,13 @@ function parseClassesFromFile(realm: string, filename: string, classPrefix = '')
                 if (attr._attributes?.type) {
                     xsdType = attr._attributes?.type as string
                 } else {
-                    restrictions = 
+                    restrictions =
                         attr['xs:simpleType'][0]['xs:restriction'] ||
                         attr['xs:simpleType'][0]['xs:union'][0]['xs:simpleType'][0]['xs:restriction']
 
                     xsdType = restrictions[0]._attributes.base
 
-                    allowEmptyString = 
+                    allowEmptyString =
                         attr['xs:simpleType'][0]['xs:union']?.[0]._attributes['memberTypes'] === 'emptyString'
                 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isoxml",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "isoxml",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@turf/turf": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isoxml",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "JavaScript library to parse and generate ISOXML (ISO11783-10) files",
   "keywords": [
     "isoxml",

--- a/src/ISOXMLManager.ts
+++ b/src/ISOXMLManager.ts
@@ -258,8 +258,8 @@ export class ISOXMLManager {
         }
     }
 
-    public getParsedFile(filenameWithExtension: string, isBinary: true): Promise<Uint8Array> 
-    public getParsedFile(filenameWithExtension: string, isBinary: false): Promise<string> 
+    public getParsedFile(filenameWithExtension: string, isBinary: true): Promise<Uint8Array>
+    public getParsedFile(filenameWithExtension: string, isBinary: false): Promise<string>
     public getParsedFile(
         filenameWithExtension: string,
         isBinary: boolean,

--- a/src/entities/AttachedFile.ts
+++ b/src/entities/AttachedFile.ts
@@ -45,7 +45,7 @@ export class ExtendedAttachedFile extends AttachedFile {
         return entity
     }
 
-    toXML(): XMLElement { 
+    toXML(): XMLElement {
         if (this.attributes.FileType === 1) {
             const linkListFile = ExtendedISO11783LinkListFile.fromISOXMLManager(this.isoxmlManager)
 
@@ -53,12 +53,12 @@ export class ExtendedAttachedFile extends AttachedFile {
                 [TAGS.ISO11783LinkListFile]: linkListFile.toXML()
             }
             const xmlString = js2xml(json)
-            this.isoxmlManager.addFileToSave(xmlString, this.attributes.FilenameWithExtension) 
+            this.isoxmlManager.addFileToSave(xmlString, this.attributes.FilenameWithExtension)
         } else {
-            this.isoxmlManager.addFileToSave(this.fileData, this.attributes.FilenameWithExtension) 
+            this.isoxmlManager.addFileToSave(this.fileData, this.attributes.FilenameWithExtension)
         }
-        return super.toXML() 
-    } 
+        return super.toXML()
+    }
 
     static linkListFromISOXMLManager(isoxmlManager: ISOXMLManager): ExtendedAttachedFile {
         return new ExtendedAttachedFile({
@@ -66,7 +66,7 @@ export class ExtendedAttachedFile extends AttachedFile {
             Preserve: AttachedFilePreserveEnum.PreserveOnTaskControllerAndSendBackToFMIS,
             FileType: 1,
             ManufacturerGLN: ''
-        }, isoxmlManager) 
+        }, isoxmlManager)
     }
 }
 

--- a/src/entities/Grid/CellCenterBasedGridGenerator.ts
+++ b/src/entities/Grid/CellCenterBasedGridGenerator.ts
@@ -111,11 +111,12 @@ export class FeatureFinder {
 // Simplified algorithm: just check the center of cell
 export function cellCenterBasedGridGenerator(
     geometry: FeatureCollection<Geometry>,
+    propertyNames: string[],
     gridParams: GridParameters
 ): ArrayBuffer {
     //   const initDate = +new Date()
     const { minX, minY, numCols, numRows, cellWidth, cellHeight } = gridParams
-    const filelength = numCols * numRows * 4
+    const filelength = numCols * numRows * 4 * propertyNames.length
     const buffer = new ArrayBuffer(filelength)
     const int32array = new Int32Array(buffer)
 
@@ -123,14 +124,18 @@ export function cellCenterBasedGridGenerator(
 
     //   console.log('finder initialization', +new Date() - initDate)
 
+    let index = 0
     for (let y = 0; y < numRows; y++) {
         for (let x = 0; x < numCols; x++) {
             const lng = minX + (x + 0.5) * cellWidth
             const lat = minY + (y + 0.5) * cellHeight
             const feature = featureFinder.findFeature([lng, lat])
-            const value = feature ? feature.properties.DOSE : 0
 
-            int32array[y * numCols + x] = Math.round(value)
+            for (const propertyName of propertyNames) {
+                const value = Math.round(feature?.properties[propertyName] ?? 0)
+                int32array[index++] = value
+            }
+            
         }
     }
     //   console.log('cells generation', +new Date() - initDate)

--- a/src/entities/Grid/CellCenterBasedGridGenerator.ts
+++ b/src/entities/Grid/CellCenterBasedGridGenerator.ts
@@ -135,7 +135,7 @@ export function cellCenterBasedGridGenerator(
                 const value = Math.round(feature?.properties[propertyName] ?? 0)
                 int32array[index++] = value
             }
-            
+
         }
     }
     //   console.log('cells generation', +new Date() - initDate)

--- a/src/entities/Grid/DefaultGridParamsGenerator.ts
+++ b/src/entities/Grid/DefaultGridParamsGenerator.ts
@@ -5,7 +5,7 @@ import { GridParametersGenerator } from ".."
 export function createGridParamsGenerator (
     targetCellWidth: number,
     targetCellHeight: number
-): GridParametersGenerator { 
+): GridParametersGenerator {
     return (geometry: any) => {
         const [minX, minY, maxX, maxY] = turfBbox(geometry)
 
@@ -25,5 +25,5 @@ export function createGridParamsGenerator (
             cellWidth: (maxX - minX) / numCols,
             cellHeight: (maxY - minY) / numRows
         }
-    }    
+    }
 }

--- a/src/entities/Grid/Grid.spec.ts
+++ b/src/entities/Grid/Grid.spec.ts
@@ -2,6 +2,7 @@ import {readFileSync} from 'fs'
 
 import { ISOXMLManager } from '../../ISOXMLManager'
 import { ExtendedGrid } from './Grid'
+import { Task } from '../../baseEntities/Task'
 
 describe('Grid Entity', () => {
   it('should create instance from GeoJSON', async () => {
@@ -30,5 +31,21 @@ describe('Grid Entity', () => {
     expect(geoJSON).toBeTruthy()
     expect(geoJSON.features[0].properties!.DOSE).toBe(16) // 15.7 should be rounded to 16
 
+  })
+
+  it('should verify grid size correctly', async () => {
+    const isoxmlData = readFileSync('./data/task_with_grid.zip')
+    const isoxmlManager = new ISOXMLManager({version: 4})
+
+    await isoxmlManager.parseISOXMLFile(new Uint8Array(isoxmlData.buffer), 'application/zip')
+
+    const grid = isoxmlManager.getEntityByXmlId<Task>('TSK1').attributes.Grid![0] as ExtendedGrid
+
+    const anotherIsoxmlManager = new ISOXMLManager({version: 4})
+
+    grid.verifyGridSize(anotherIsoxmlManager, 1)
+    expect(anotherIsoxmlManager.getWarnings()).toHaveLength(0)
+    grid.verifyGridSize(anotherIsoxmlManager, 2)
+    expect(anotherIsoxmlManager.getWarnings()).toHaveLength(1)
   })
 })

--- a/src/entities/Grid/Grid.spec.ts
+++ b/src/entities/Grid/Grid.spec.ts
@@ -7,7 +7,7 @@ describe('Grid Entity', () => {
   it('should create instance from GeoJSON', async () => {
     const geoJSONdata = JSON.parse(readFileSync('./data/test.geojson', 'utf-8'))
     const isoxmlManager = new ISOXMLManager()
-    const grid = ExtendedGrid.fromGeoJSON(geoJSONdata, isoxmlManager)
+    const grid = ExtendedGrid.fromGeoJSON(geoJSONdata, ['DOSE'], isoxmlManager)
     expect(grid.attributes.Filelength).toBe(22896)
 
     expect(grid.attributes.GridMinimumNorthPosition).toBe(55.82481700900832)
@@ -23,12 +23,12 @@ describe('Grid Entity', () => {
   it('should convert Grid to GeoJSON', async () => {
     const geoJSONdata = JSON.parse(readFileSync('./data/test.geojson', 'utf-8'))
     const isoxmlManager = new ISOXMLManager()
-    const grid = ExtendedGrid.fromGeoJSON(geoJSONdata, isoxmlManager)
+    const grid = ExtendedGrid.fromGeoJSON(geoJSONdata, ['DOSE'], isoxmlManager)
 
-    const geoJSON = grid.toGeoJSON()
+    const geoJSON = grid.toGeoJSON(['DOSE'])
 
     expect(geoJSON).toBeTruthy()
-    expect(geoJSON.features[0].properties.DOSE).toBe(16) // 15.7 should be rounded to 16
+    expect(geoJSON.features[0].properties!.DOSE).toBe(16) // 15.7 should be rounded to 16
 
   })
 })

--- a/src/entities/Grid/IntersectionBasedGridGenerator.ts
+++ b/src/entities/Grid/IntersectionBasedGridGenerator.ts
@@ -5,10 +5,14 @@ import RBush from "rbush"
 
 import { GridParameters } from ".."
 
-export function intersectionBasedGridGenerator(geoJSON: FeatureCollection, gridParams: GridParameters): ArrayBuffer {
+export function intersectionBasedGridGenerator(
+    geoJSON: FeatureCollection,
+    propertyNames: string[],
+    gridParams: GridParameters
+): ArrayBuffer {
     const {minX, minY, numCols, numRows, cellWidth, cellHeight} = gridParams
 
-    const filelength = numCols * numRows * 4
+    const filelength = numCols * numRows * 4 * propertyNames.length
     const buffer = new ArrayBuffer(filelength)
     const int32array = new Int32Array(buffer)
 
@@ -18,6 +22,7 @@ export function intersectionBasedGridGenerator(geoJSON: FeatureCollection, gridP
         return {minX: bboxMinX, minY: bboxMinY, maxX: bboxMaxX, maxY: bboxMaxY, feature: f}
     }))
 
+    let index = 0
     for (let y = 0; y < numRows; y++) {
         const subTree = new RBush<{feature: any}>()
 
@@ -77,9 +82,10 @@ export function intersectionBasedGridGenerator(geoJSON: FeatureCollection, gridP
                 })
             }
 
-            const value = feature ? feature.properties.DOSE : 0
-
-            int32array[y * numCols + x] = Math.round(value)
+            for (const propertyName of propertyNames) {
+                const value = Math.round(feature?.properties[propertyName] ?? 0)
+                int32array[index++] = value
+            }
         }
     }
 

--- a/src/entities/ISO11783LinkListFile.ts
+++ b/src/entities/ISO11783LinkListFile.ts
@@ -28,7 +28,7 @@ export class ExtendedISO11783LinkListFile extends ISO11783LinkListFile {
             ExtendedISO11783LinkListFile
         ) as ISO11783LinkListFile
 
-        const linkGroup = entity.attributes.LinkGroup?.find(group => 
+        const linkGroup = entity.attributes.LinkGroup?.find(group =>
             group.attributes.LinkGroupType === LinkGroupLinkGroupTypeEnum.UniqueResolvableURIs &&
             group.attributes.LinkGroupNamespace === isoxmlManager.options.fmisURI
         )
@@ -39,14 +39,14 @@ export class ExtendedISO11783LinkListFile extends ISO11783LinkListFile {
         return entity
     }
 
-    toXML(): XMLElement { 
+    toXML(): XMLElement {
         this.attributes.LinkGroup = []
         if (this.isoxmlManager.options.fmisURI) {
             const links = Object.values(this.isoxmlManager.xmlReferences)
                 .filter(ref => ref.fmisId)
                 .map(ref => new Link({
                     ObjectIdRef: ref,
-                    LinkValue: ref.fmisId 
+                    LinkValue: ref.fmisId
                 }, this.isoxmlManager))
             const linkGroup = this.isoxmlManager.createEntityFromAttributes<LinkGroup>(TAGS.LinkGroup, {
                 LinkGroupType: LinkGroupLinkGroupTypeEnum.UniqueResolvableURIs,
@@ -56,8 +56,8 @@ export class ExtendedISO11783LinkListFile extends ISO11783LinkListFile {
             this.isoxmlManager.registerEntity(linkGroup)
             this.attributes.LinkGroup = [linkGroup]
         }
-        return super.toXML() 
-    } 
+        return super.toXML()
+    }
 
     static fromISOXMLManager(isoxmlManager: ISOXMLManager): ExtendedISO11783LinkListFile {
         const version = isoxmlManager.options.version

--- a/src/entities/ISO11783TaskDataFile.ts
+++ b/src/entities/ISO11783TaskDataFile.ts
@@ -27,7 +27,7 @@ function isoxmlManagerOptionsToAttributes(isoxmlManager: ISOXMLManager) {
 
 // This implementation doesn't support generation of External Files. Particularly:
 //   * During parsing from XML, all the external files will be parsed and merged into the instance of this class.
-//     All the XFR tags will be removed 
+//     All the XFR tags will be removed
 //   * During saving to XML, no external files will be saved even if XFR tags were manually added by user
 export class ExtendedISO11783TaskDataFile extends ISO11783TaskDataFile {
     public tag = TAGS.ISO11783TaskDataFile

--- a/src/entities/Partfield.ts
+++ b/src/entities/Partfield.ts
@@ -24,7 +24,7 @@ export class ExtendedPartfield extends Partfield {
     }
 
     boundaryFromGeoJSON(geoJSON: TurfMultiPolygon | TurfPolygon, isoxmlManager: ISOXMLManager): void {
-        this.attributes.PolygonnonTreatmentZoneonly = 
+        this.attributes.PolygonnonTreatmentZoneonly =
             ExtendedPolygon.fromGeoJSON(geoJSON, PolygonPolygonTypeEnum.PartfieldBoundary, isoxmlManager)
         this.attributes.PartfieldArea = Math.round(area(geoJSON))
     }

--- a/src/entities/Polygon.spec.ts
+++ b/src/entities/Polygon.spec.ts
@@ -26,6 +26,7 @@ describe('Polygon Entity', () => {
             PolygonPolygonTypeEnum.TreatmentZone,
             isoxmlManager
         )
+        const xml = polygons[0].toXML()
         expect(polygons).toHaveLength(1)
         expect(stat(polygons[0])).toEqual({inner: 2, outer: 2})
     })

--- a/src/entities/Polygon.spec.ts
+++ b/src/entities/Polygon.spec.ts
@@ -26,7 +26,6 @@ describe('Polygon Entity', () => {
             PolygonPolygonTypeEnum.TreatmentZone,
             isoxmlManager
         )
-        const xml = polygons[0].toXML()
         expect(polygons).toHaveLength(1)
         expect(stat(polygons[0])).toEqual({inner: 2, outer: 2})
     })

--- a/src/entities/Polygon.ts
+++ b/src/entities/Polygon.ts
@@ -39,7 +39,7 @@ export class ExtendedPolygon extends Polygon {
                 ...geoJSON.coordinates.map(
                     component => component.map(
                         (ring, idx) => ExtendedLineString.fromGeoJSONCoordinates(
-                            ring, 
+                            ring,
                             isoxmlManager,
                             idx
                                 ? LineStringLineStringTypeEnum.PolygonInterior
@@ -58,7 +58,7 @@ export class ExtendedPolygon extends Polygon {
                 PolygonType: polygonType,
                 LineString: component.map(
                     (ring, idx) => ExtendedLineString.fromGeoJSONCoordinates(
-                        ring, 
+                        ring,
                         isoxmlManager,
                             idx
                                 ? LineStringLineStringTypeEnum.PolygonInterior
@@ -94,7 +94,7 @@ export class ExtendedPolygon extends Polygon {
                 if (outerRings.length <= 1) {
                     splittedPolygons.push(polygon)
                     return
-                } 
+                }
 
                 const innerRings = polygon.attributes.LineString
                     .filter((ring) => ring.attributes.LineStringType === LineStringLineStringTypeEnum.PolygonInterior)

--- a/src/entities/Task.spec.ts
+++ b/src/entities/Task.spec.ts
@@ -18,7 +18,7 @@ describe('Task Entity', () => {
             [isoxmlManager.createEntityFromAttributes(TAGS.ProcessDataVariable, {ProcessDataDDI: '0001'})],
             ['DOSE']
         )
-        
+
         expect(task.attributes.TreatmentZone).toHaveLength(2)
         expect(task.attributes.Grid).toHaveLength(1)
     })

--- a/src/entities/TimeLog/index.ts
+++ b/src/entities/TimeLog/index.ts
@@ -92,16 +92,16 @@ export class ExtendedTimeLog extends TimeLog {
         return this.isoxmlManager.getEntityByXmlId<ExtendedDeviceElement>(detId)
     }
 
-    toXML(): XMLElement { 
+    toXML(): XMLElement {
         const json = {
             [TAGS.Time]: this.timeLogHeader.toXML()
         }
         const xmlData = js2xml(json)
 
-        this.isoxmlManager.addFileToSave(xmlData, `${this.attributes.Filename}.xml`) 
-        this.isoxmlManager.addFileToSave(this.binaryData, `${this.attributes.Filename}.bin`) 
-        return super.toXML() 
-    } 
+        this.isoxmlManager.addFileToSave(xmlData, `${this.attributes.Filename}.xml`)
+        this.isoxmlManager.addFileToSave(this.binaryData, `${this.attributes.Filename}.bin`)
+        return super.toXML()
+    }
 
     parseBinaryFile(): TimeLogInfo {
 
@@ -296,7 +296,7 @@ export class ExtendedTimeLog extends TimeLog {
         })
 
         const newValuesInfo = parsedTimeLog.valuesInfo.map(valueInfo => {
-            const values = [...uniqueValues[valueInfo.valueKey]] 
+            const values = [...uniqueValues[valueInfo.valueKey]]
             if (values.length < 8) {
                 return {minValue: valueInfo.minValue, maxValue: valueInfo.maxValue}
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,7 +107,7 @@ function xml2attrs(
                 // warn about unknown non-proprietary attributes
                 isoxmlManager.addWarning(`[${internalId}] Unknown attribute "${xmlAttr}"`)
             }
-            return 
+            return
         }
         if (attrDescription.isPrimaryId) {
             return
@@ -177,7 +177,7 @@ export async function xml2ChildTags(
                 result['ProprietaryTags'][tagName] = result['ProprietaryTags'][tagName] || []
                 result['ProprietaryTags'][tagName].push(...xml[tagName])
             }
-            continue 
+            continue
         }
         result[refDescription.name] = []
         for (const [idx, childXml] of xml[tagName].entries()) {
@@ -187,7 +187,7 @@ export async function xml2ChildTags(
             )
         }
     }
-    return result 
+    return result
 }
 
 export function childTags2Xml(
@@ -202,12 +202,12 @@ export function childTags2Xml(
         const tagName = Object.keys(referencesDescription).find(tag => referencesDescription[tag].name === attrName)
         const refDescription = referencesDescription[tagName]
         if (!refDescription || (version === 3 && refDescription.isOnlyV4)) {
-            return 
+            return
         }
 
         result[tagName] = (entity.attributes[attrName] as Entity[]).map(entity => entity.toXML())
     })
-    return result 
+    return result
 }
 
 export async function fromXML(

--- a/src/xmlManager.ts
+++ b/src/xmlManager.ts
@@ -9,7 +9,7 @@ const XML_PARSE_OPTIONS: X2jOptionsOptional = {
     parseTagValue: false,
     parseAttributeValue: false,
     isArray: (tagName: string, jPath: string, isLeafNode: boolean, isAttribute: boolean) => !isAttribute,
-    attributeValueProcessor: (name: string, value: string) => 
+    attributeValueProcessor: (name: string, value: string) =>
         value.replace(/&amp;/g, '&')
           .replace(/&apos;/g, "'")
           .replace(/&quot;/g, '"')
@@ -22,7 +22,7 @@ const XML_BUILD_OPTIONS: XmlBuilderOptionsOptional = {
     ignoreAttributes: false,
     attributesGroupName: '_attributes',
     format: true,
-    attributeValueProcessor: (name: string, value: string) => 
+    attributeValueProcessor: (name: string, value: string) =>
         value.replace(/&/g, '&amp;')
           .replace(/'/g, '&apos;')
           .replace(/"/g, '&quot;')


### PR DESCRIPTION
Changes:
* Adds possibility to parse and generate multi-value Grids of Type 2. Multi-value means that Grid's Timezone has multiple ProcessDataVariables
* Fixed warning of Grid size (for multi-value grids) (fixes #23)
* Add one more linter rule
* Add more tests